### PR TITLE
VIVO-1734: Removed  "(one-time permission)" from language property files

### DIFF
--- a/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
@@ -820,7 +820,7 @@ orcid_step1_confirm = Step 1: Adding your ORCID iD
 
 orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
 <li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
-<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may read your ORCID record.</li> \
 <li>VIVO reads your ORCID record.</li> \
 <li>VIVO notes that your ORCID iD is confirmed.</li></ul>
 
@@ -835,7 +835,7 @@ orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
 orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
 
 orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
-<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record.</li> \
 <li>VIVO adds the external ID.</li></ul>
 
 orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>

--- a/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all_en_US.properties
@@ -820,7 +820,7 @@ orcid_step1_confirm = Step 1: Adding your ORCID iD
 
 orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
 <li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
-<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may read your ORCID record.</li> \
 <li>VIVO reads your ORCID record.</li> \
 <li>VIVO notes that your ORCID iD is confirmed.</li></ul>
 
@@ -835,7 +835,7 @@ orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
 orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
 
 orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
-<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record.</li> \
 <li>VIVO adds the external ID.</li></ul>
 
 orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>

--- a/webapp/src/main/webapp/i18n/vivo_all_es.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all_es.properties
@@ -822,7 +822,7 @@ orcid_step1_confirm = Step 1: Adding your ORCID iD
 
 orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
 <li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
-<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may read your ORCID record.</li> \
 <li>VIVO reads your ORCID record.</li> \
 <li>VIVO notes that your ORCID iD is confirmed.</li></ul>
 
@@ -837,7 +837,7 @@ orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
 orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
 
 orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
-<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record.</li> \
 <li>VIVO adds the external ID.</li></ul>
 
 orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>

--- a/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
+++ b/webapp/src/main/webapp/i18n/vivo_all_pt_BR.properties
@@ -821,7 +821,7 @@ orcid_step1_confirm = Step 1: Adding your ORCID iD
 
 orcid_step1_description = <ul><li>VIVO redirects you to ORCID's web site.</li> \
 <li>You log in to your ORCID account. <ul class="inner"><li>If you don't have an account, you can create one.</li></ul></li> \
-<li>You tell ORCID that VIVO may read your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may read your ORCID record.</li> \
 <li>VIVO reads your ORCID record.</li> \
 <li>VIVO notes that your ORCID iD is confirmed.</li></ul>
 
@@ -836,7 +836,7 @@ orcid_step1_confirmed = <p>Your ORCID iD is confirmed as {0}</p>
 orcid_step2_heading = Step 2 (recommended): Linking your ORCID record to VIVO
 
 orcid_step2_description = <ul><li>VIVO redirects you to ORCID's web site</li> \
-<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record. (one-time permission)</li> \
+<li>You tell ORCID that VIVO may add an "external ID" to your ORCID record.</li> \
 <li>VIVO adds the external ID.</li></ul>
 
 orcid_step2_already_present = <p>Your ORCID record already includes a link to VIVO.</p>


### PR DESCRIPTION
See https://jira.duraspace.org/projects/VIVO/issues/VIVO-1734 for more information