### PR TITLE
 core#AdviseeRole = "Rolle als betreute Person"

### DIFF
--- a/home/src/main/resources/rdf/tbox/everytime/initialTBoxAnnotations_de_DE.nt
+++ b/home/src/main/resources/rdf/tbox/everytime/initialTBoxAnnotations_de_DE.nt
@@ -251,7 +251,7 @@
 <http://vivoweb.org/ontology/core#Course> <http://www.w3.org/2000/01/rdf-schema#label> "Lehrveranstaltung"@de-DE .
 <http://purl.org/ontology/bibo/CollectedDocument> <http://www.w3.org/2000/01/rdf-schema#label> "Erfasstes Dokument"@de-DE .
 <http://vivoweb.org/ontology/core#Newsletter> <http://www.w3.org/2000/01/rdf-schema#label> "Newsletter"@de-DE .
-<http://vivoweb.org/ontology/core#AdviseeRole> <http://www.w3.org/2000/01/rdf-schema#label> "Rolle als BetreuerIn"@de-DE .
+<http://vivoweb.org/ontology/core#AdviseeRole> <http://www.w3.org/2000/01/rdf-schema#label> "Rolle als betreute Person"@de-DE .
 <http://vivoweb.org/ontology/core#proceedingsOf> <http://www.w3.org/2000/01/rdf-schema#label> "Tagungsband von"@de-DE .
 <http://vivoweb.org/ontology/core#researchOverview> <http://www.w3.org/2000/01/rdf-schema#label> "Übersicht zur Forschung"@de-DE .
 <http://vivoweb.org/ontology/core#supplementalInformation> <http://www.w3.org/2000/01/rdf-schema#label> "Ergänzende Informationen"@de-DE .


### PR DESCRIPTION
Solution for https://github.com/VIVO-DE/VIVO-languages/issues/32 

Changed German label for core#AdviseeRole to "Rolle als betreute Person"