### PR TITLE
Fixed translation for Faculty of 1000

### DIFF
--- a/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
+++ b/de_DE/webapp/src/main/webapp/i18n/vivo_all_de_DE.properties
@@ -247,7 +247,7 @@ edit_wbpage_of = Webseite bearbeiten von
 add_webpage_for = Webseite hinzufügen für
 add_webpage = Webseite hinzufügen
 url_type = URL-Typ
-faculty_of_1000 = Fakultät mit 1000 Links
+faculty_of_1000 = Faculty-of-1000-Link
 standard_web_link = Standard-Weblink
 webpage_name = Name der Webseite
 


### PR DESCRIPTION
The current translation does not make sense, it just translates a brand name into German. Now the actual name of the website is used. 